### PR TITLE
Render markers

### DIFF
--- a/src/consts/multiplechoice.js
+++ b/src/consts/multiplechoice.js
@@ -1,0 +1,15 @@
+export const CHOICES = {
+  severity: ['Low Impact', 'Significant Impact', 'Very High Impact'],
+  category: [
+    'Trash',
+    'Traffic',
+    'Public Property Damage',
+    'Public Transport',
+    'Other',
+  ],
+};
+
+export function createPicker(label) {
+  const options = CHOICES[label];
+  return options.map((option, index) => ({label: option, value: index + 1}));
+}

--- a/src/context/IssueContext.js
+++ b/src/context/IssueContext.js
@@ -8,7 +8,7 @@ export default IssuesContext;
 const queryClient = new QueryClient();
 const GET_ISSUES = 'GET_ISSUES';
 
-async function fetchData() {
+export async function fetchData() {
   console.log('Trying to connect');
   const response = await fetch(`${ISSUES_URL}/issues/`);
   const json = await response.json();

--- a/src/context/IssueContext.js
+++ b/src/context/IssueContext.js
@@ -9,7 +9,7 @@ const queryClient = new QueryClient();
 const GET_ISSUES = 'GET_ISSUES';
 
 async function fetchData() {
-  console.log('Trying to conect');
+  console.log('Trying to connect');
   const response = await fetch(`${ISSUES_URL}/issues/`);
   const json = await response.json();
   return json;

--- a/src/views/CreateIssue.js
+++ b/src/views/CreateIssue.js
@@ -1,6 +1,6 @@
-import React, {useState, useRef} from 'react';
+import React, {useState} from 'react';
 import {Form, FormItem, Picker} from 'react-native-form-component';
-import {View, Text} from 'react-native';
+import {createPicker} from '../consts/multiplechoice';
 
 export default function CreateIssue({navigation, route}) {
   const [title, setTitle] = useState('Title');
@@ -31,11 +31,7 @@ export default function CreateIssue({navigation, route}) {
         asterik
       />
       <Picker
-        items={[
-          {label: 'Low Impact', value: 1},
-          {label: 'Significant Impact', value: 2},
-          {label: 'Very High Impact', value: 3},
-        ]}
+        items={createPicker('severity')}
         label="Severity"
         selectedValue={severity}
         onSelection={item => setSeverity(item.value)}
@@ -43,13 +39,7 @@ export default function CreateIssue({navigation, route}) {
         asterik
       />
       <Picker
-        items={[
-          {label: 'Trash', value: 1},
-          {label: 'Traffic', value: 2},
-          {label: 'Public Property Damage', value: 3},
-          {label: 'Public Transport', value: 4},
-          {label: 'Other', value: 5},
-        ]}
+        items={createPicker('category')}
         label="Category"
         selectedValue={category}
         onSelection={item => setCategory(item.value)}

--- a/src/views/IssueDetail.js
+++ b/src/views/IssueDetail.js
@@ -1,7 +1,8 @@
-import React, {useLayoutEffect} from 'react';
+import React, {useLayoutEffect, useState} from 'react';
 import {
   ActivityIndicator,
   Button,
+  Dimensions,
   Image,
   StyleSheet,
   Text,
@@ -12,9 +13,8 @@ import {URI_IMAGE} from '../consts/backend';
 
 const styles = StyleSheet.create({
   image: {
-    width: 100,
-    height: 100,
-    marginRight: 10,
+    marginTop: 10,
+    marginBottom: 10,
     resizeMode: 'contain',
   },
 });
@@ -22,6 +22,8 @@ const styles = StyleSheet.create({
 export default function IssueDetail({navigation, route}) {
   const {issueId} = route.params;
   const {data: issue, isLoading, isSuccess} = useIssue({issueId});
+  const [imgRatio, setImgRatio] = useState(0);
+  const width = Dimensions.get('window').width;
 
   useLayoutEffect(function () {
     if (isSuccess) {
@@ -50,13 +52,21 @@ export default function IssueDetail({navigation, route}) {
     );
   }
 
+  Image.getSize(`${URI_IMAGE}${issue.image}`, (w, h) => {
+    setImgRatio(h / w);
+  });
+
   return (
     <View>
       {/*{issue.image && <Image source={{uri: issue.image}} style={styles.image} />}*/}
       {issue.image && (
         <Image
           source={{uri: `${URI_IMAGE}${issue.image}`}}
-          style={styles.image}
+          style={{
+            ...styles.image,
+            width: width,
+            height: imgRatio * width,
+          }}
         />
       )}
       <Text>Id: {issue._id}</Text>

--- a/src/views/IssueDetail.js
+++ b/src/views/IssueDetail.js
@@ -4,12 +4,14 @@ import {
   Button,
   Dimensions,
   Image,
+  ScrollView,
   StyleSheet,
   Text,
   View,
 } from 'react-native';
 import useIssue from '../hooks/useIssue';
 import {URI_IMAGE} from '../consts/backend';
+import {CHOICES} from '../consts/multiplechoice';
 
 const styles = StyleSheet.create({
   image: {
@@ -17,13 +19,28 @@ const styles = StyleSheet.create({
     marginBottom: 10,
     resizeMode: 'contain',
   },
+  title: {
+    color: '#000000',
+    fontSize: 40,
+    fontWeight: 'bold',
+    alignSelf: 'center',
+  },
+  label: {
+    color: '#000000',
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+  value: {
+    color: '#000000',
+    fontSize: 18,
+  },
 });
 
 export default function IssueDetail({navigation, route}) {
   const {issueId} = route.params;
   const {data: issue, isLoading, isSuccess} = useIssue({issueId});
   const [imgRatio, setImgRatio] = useState(0);
-  const width = Dimensions.get('window').width;
+  const {width, height} = Dimensions.get('window');
 
   useLayoutEffect(function () {
     if (isSuccess) {
@@ -57,8 +74,8 @@ export default function IssueDetail({navigation, route}) {
   });
 
   return (
-    <View>
-      {/*{issue.image && <Image source={{uri: issue.image}} style={styles.image} />}*/}
+    <ScrollView style={{backgroundColor: '#FFF', height}}>
+      <Text style={styles.title}>{issue.title}</Text>
       {issue.image && (
         <Image
           source={{uri: `${URI_IMAGE}${issue.image}`}}
@@ -69,19 +86,25 @@ export default function IssueDetail({navigation, route}) {
           }}
         />
       )}
-      <Text>Id: {issue._id}</Text>
-      <Text>Issue: {issue.title}</Text>
-      <Text>Description: {issue.description}</Text>
-      <Text>Date: {issue.date}</Text>
-      <Text>Status: {issue.status}</Text>
-      <Text>Severity: {issue.severity}</Text>
-      <Text>Category: {issue.category}</Text>
-      <View>
+      <Field label="Description:" value={issue.description} />
+      <Field label="Date:" value={issue.date} />
+      <Field label="Severity:" value={CHOICES.severity[issue.severity - 1]} />
+      <Field label="Category:" value={CHOICES.category[issue.category - 1]} />
+      {/* <View>
         <Text>Votes</Text>
         {issue.votes.map(vote => (
           <Text key={`vote--${vote._id}`}>{vote._id}</Text>
         ))}
-      </View>
+      </View> */}
+    </ScrollView>
+  );
+}
+
+function Field({label, value}) {
+  return (
+    <View style={{paddingTop: 10}}>
+      <Text style={styles.label}>{label}</Text>
+      <Text style={styles.value}>{value}</Text>
     </View>
   );
 }

--- a/src/views/Maps.js
+++ b/src/views/Maps.js
@@ -1,21 +1,29 @@
 /* eslint-disable react-native/no-inline-styles */
-import React from 'react';
-import {SafeAreaView, Text, View} from 'react-native';
+import React, {useEffect, useState} from 'react';
+import {SafeAreaView, View} from 'react-native';
 import MapView, {PROVIDER_GOOGLE, Marker} from 'react-native-maps';
 import {Dimensions, Pressable} from 'react-native';
 import IconFA from 'react-native-vector-icons/FontAwesome';
 import IconAD from 'react-native-vector-icons/AntDesign';
-import {NavigationContainer} from '@react-navigation/native';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import CreateIssue from './CreateIssue';
-import {createAppContainer} from 'react-navigation';
+import {fetchData} from '../context/IssueContext';
 
 function Map({navigation}) {
   const {height, width} = Dimensions.get('window');
+  const [issues, setIssues] = useState([]);
+
+  useEffect(() => {
+    const f = async () => {
+      setIssues(await fetchData());
+    };
+    f();
+  }, []);
+
   return (
     <SafeAreaView style={{flex: 1}}>
       <MapView
-        initialRegion={{
+        region={{
           latitude: 37.78825,
           longitude: -122.4324,
           latitudeDelta: 0.0922,
@@ -27,7 +35,9 @@ function Map({navigation}) {
           height: height,
           width: width,
         }}>
-        <Marker coordinate={{latitude: 37.78825, longitude: -122.4324}} />
+        {issues.map((issue, index) => (
+          <Marker key={index} coordinate={issue.location} />
+        ))}
       </MapView>
       <Pressable onPress={() => navigation.navigate('CreateIssue')}>
         <View

--- a/src/views/Maps.js
+++ b/src/views/Maps.js
@@ -8,6 +8,7 @@ import IconAD from 'react-native-vector-icons/AntDesign';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import CreateIssue from './CreateIssue';
 import {fetchData} from '../context/IssueContext';
+import IssueDetail from './IssueDetail';
 
 function Map({navigation}) {
   const {height, width} = Dimensions.get('window');
@@ -36,7 +37,13 @@ function Map({navigation}) {
           width: width,
         }}>
         {issues.map((issue, index) => (
-          <Marker key={index} coordinate={issue.location} />
+          <Marker
+            key={index}
+            coordinate={issue.location}
+            onPress={() =>
+              navigation.navigate('IssueDetail', {issueId: issue._id})
+            }
+          />
         ))}
       </MapView>
       <Pressable onPress={() => navigation.navigate('CreateIssue')}>
@@ -68,6 +75,7 @@ export default function Maps() {
     <Stack.Navigator>
       <Stack.Screen name="Map" component={Map} />
       <Stack.Screen name="CreateIssue" component={CreateIssue} />
+      <Stack.Screen name="IssueDetail" component={IssueDetail} />
     </Stack.Navigator>
   );
 }


### PR DESCRIPTION
This PR renders all markers in the db, opens issue detail page after press in marker and also improves issue detail page visuals slightly.

Further improvements needed:

* Only render markers that fit inside window
* Filter markers by category, severity, etc.
* Show vote count
* Create upvote/downvote buttons
* Move Edit button to the bottom of the page
* Make edit page more similar to creation page

Visuals:

<img width="329" alt="image" src="https://user-images.githubusercontent.com/38197419/212375419-364e1133-831e-4623-88d5-4d60e18427c1.png">

<img width="325" alt="image" src="https://user-images.githubusercontent.com/38197419/212375338-11746973-7a06-4d18-8ca0-82c2d9a8f76f.png">
